### PR TITLE
Add Package-Requires header for ELPA installations

### DIFF
--- a/troncle.el
+++ b/troncle.el
@@ -1,12 +1,18 @@
 ;;; troncle.el --- Emacs convenience functions for tracing clojure code
+
 ;; Version: 0.1.1
 ;; Author: Alex Coventry
 ;; URL: https://github.com/coventry/troncle
+;; Package-Requires: ((nrepl "0.2.0"))
+
+;;; Commentary:
 
 ;; A library of functions for quickly wrapping and executing clojure
 ;; code with tracing instrumentation.  See
 ;; https://github.com/coventry/troncle for usage and installation
 ;; instructions.
+
+;;; Code:
 
 (require 'clojure-mode)
 (require 'nrepl)


### PR DESCRIPTION
This commit also fixes the header format so that package repositories such as Marmalade can extract the commentary text.

P.S. I'd like to add a recipe for troncle to [MELPA](http://melpa.milkbox.net/), but it would need to be updated for the recent `nrepl` -> `cider` rename first. Please ping me when/if that gets done in case I don't notice. :-)
