### PR TITLE
two fixes

### DIFF
--- a/src/troncle/discover.clj
+++ b/src/troncle/discover.clj
@@ -8,6 +8,7 @@
   (:require [clojure.tools.nrepl.transport :as t]
             [clojure.tools.nrepl.misc :as m]
             [clojure.tools.nrepl.middleware.session :as ses]
+            [troncle.emacs]
             [clojure.repl]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/troncle/emacs.clj
+++ b/src/troncle/emacs.clj
@@ -1,7 +1,6 @@
 (ns troncle.emacs
   (:require [troncle.core :as c]
-            [troncle.traces :as traces]
-            [troncle.discover :as discover]))
+            [troncle.traces :as traces]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Interface with emacs

--- a/troncle.el
+++ b/troncle.el
@@ -56,25 +56,28 @@ troncle-set-exec-var for a way to set this.)
 			   "trace-region" (str (list fn rstart rend)))
 		     (troncle-op-handler (current-buffer))))))
 
-(defun troncle-discover-choose-var (ns)
+(defun troncle-discover-choose-var (ns exec-fn)
   "Choose a var to be executed when forms are sent for tracing
 instrumentation with troncle-trace-region.  The var must be a fn
-which takes no arguments."
-  (let ((troncle-discover-var nil)) ; poor man's promises
+which takes no arguments. Invokes exec-fn with the fully
+qualified var-name as string."
+  (lexical-let ((exec-fn exec-fn))
     (nrepl-ido-read-var (or ns "user")
-                        (lambda (var) (setq troncle-discover-var var)))
-    ;; async? more like ehsync.
-    (while (not troncle-discover-var)
-      (sit-for 0.01))
-    (concat nrepl-ido-ns "/" troncle-discover-var)))
+                        (lambda (var)
+                          (funcall exec-fn
+                                   (concat nrepl-ido-ns "/"
+                                   var))))))
 
 ;;;###autoload
 (defun troncle-set-exec-var ()
   (interactive)
-  (nrepl-send-op "set-exec-var"
-		 (list "var" (troncle-discover-choose-var
-			      (clojure-find-ns)))
-		 (troncle-op-handler (current-buffer))))
+  (lexical-let ((handler (troncle-op-handler (current-buffer))))
+    (troncle-discover-choose-var
+     (clojure-find-ns)
+     (lambda (var)
+       (nrepl-send-op "set-exec-var"
+                      (list "var" var)
+                      handler)))))
 
 
 (eval-after-load 'clojure-mode


### PR DESCRIPTION
I think I found the bug I was talking about on IRC yesterday. The problem was that the troncle.emacs namespace was not loaded anywhere and thus the ops function in discover did not find the op and would not dispatch it later. I have removed the dependency for troncle.discover in troncle.emacs (as it was unused) and instead added a dependendy for troncle.emacs in troncle.discover.

The other fix deals with the selection when choosing an exec-var. I am not sure if I oversaw something. For me it works as it is written. If the pseudo-async stuff is really necessary we need another fix because hitting C-g kills emacs forever otherwise.
